### PR TITLE
fix: Change filename StackNavigator to Main

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,22 +1,16 @@
 import React from 'react';
 import 'react-native-gesture-handler';
 import {NavigationContainer} from '@react-navigation/native';
-// import {Provider as ReduxProvider} from 'react-redux';
-import TabNavigator from './srcs/screen/TabNavigator';
-
-// const store = makeStore();
+// import TabNavigator from './srcs/screen/TabNavigator';
+import Main from './srcs/screen/Main';
 
 const App = () => {
   return (
-    // <ReduxProvider store={store}>
     <NavigationContainer>
-      <TabNavigator />
+      {/* <TabNavigator /> */}
+      <Main />
     </NavigationContainer>
-    // </ReduxProvider>
   );
 };
 
 export default App;
-function makeStore() {
-  throw new Error('Function not implemented.');
-}

--- a/srcs/screen/AddAlarm.style.tsx
+++ b/srcs/screen/AddAlarm.style.tsx
@@ -1,0 +1,33 @@
+import {StyleSheet} from 'react-native';
+import {MD2Colors as Colors} from 'react-native-paper';
+
+export const styles = StyleSheet.create({
+  view: {
+    flex: 1,
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  tapListView: {
+    flexDirection: 'column',
+    alignSelf: 'center',
+    width: '90%',
+    marginLeft: 10,
+    marginRight: 10,
+    borderRadius: 5,
+    backgroundColor: Colors.grey200,
+  },
+  tapItemView: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: 'transparent',
+    marginLeft: 12,
+    marginRight: 12,
+    margin: 10,
+  },
+  separator: {
+    height: 1,
+    marginHorizontal: 20,
+    backgroundColor: 'lightgray',
+  },
+});

--- a/srcs/screen/AddAlarm.tsx
+++ b/srcs/screen/AddAlarm.tsx
@@ -1,13 +1,14 @@
-import React, {useLayoutEffect, useRef, useState} from 'react';
+import React, {useLayoutEffect, useState} from 'react';
 import DateTimePicker from '@react-native-community/datetimepicker';
 //prettier-ignore
-import { Pressable, StyleSheet, Text, View, Switch, FlatList} from 'react-native';
+import { Pressable, Text, View, Switch, FlatList} from 'react-native';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import {StackNavigationProp} from '@react-navigation/stack';
 import {useNavigation} from '@react-navigation/native';
-import {ModalStackParamList} from './StackNavigator';
+import {ModalStackParamList} from './Main';
 import {MD2Colors as Colors} from 'react-native-paper';
 import {AlarmType, createAlarm} from '../libs/alarm';
+import {styles} from './AddAlarm.style';
 
 type AlarmScreenProp = StackNavigationProp<ModalStackParamList, 'AddAlarm'>;
 
@@ -99,36 +100,5 @@ const AddAlarm = () => {
     </View>
   );
 };
-
-const styles = StyleSheet.create({
-  view: {
-    flex: 1,
-    flexDirection: 'column',
-    alignItems: 'center',
-  },
-  tapListView: {
-    flexDirection: 'column',
-    alignSelf: 'center',
-    width: '90%',
-    marginLeft: 10,
-    marginRight: 10,
-    borderRadius: 5,
-    backgroundColor: Colors.grey200,
-  },
-  tapItemView: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    backgroundColor: 'transparent',
-    marginLeft: 12,
-    marginRight: 12,
-    margin: 10,
-  },
-  separator: {
-    height: 1,
-    marginHorizontal: 20,
-    backgroundColor: 'lightgray',
-  },
-});
 
 export default AddAlarm;

--- a/srcs/screen/AddAlarmDetail/Message.tsx
+++ b/srcs/screen/AddAlarmDetail/Message.tsx
@@ -3,7 +3,7 @@ import {Pressable, StyleSheet, Text, TextInput, View} from 'react-native';
 import {MD2Colors as Colors} from 'react-native-paper';
 import {AutoFocusProvider, useAutoFocus} from '../../contexts';
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native';
-import {ModalStackParamList} from '../StackNavigator';
+import {ModalStackParamList} from '../Main';
 import {StackNavigationProp} from '@react-navigation/stack';
 
 type messageScreenProps = StackNavigationProp<ModalStackParamList, 'Message'>;

--- a/srcs/screen/AddAlarmDetail/Song.tsx
+++ b/srcs/screen/AddAlarmDetail/Song.tsx
@@ -3,7 +3,7 @@ import {FlatList, Text, TouchableOpacity, View} from 'react-native';
 import {MD2Colors as Colors} from 'react-native-paper';
 import {useNavigation} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
-import {ModalStackParamList} from '../StackNavigator';
+import {ModalStackParamList} from '../Main';
 import {styles} from './ButtonList.styles';
 type songScreenProps = StackNavigationProp<ModalStackParamList, 'Song'>;
 // type songRouteProps = RouteProp<ModalStackParamList, 'Song'>;

--- a/srcs/screen/Home.tsx
+++ b/srcs/screen/Home.tsx
@@ -4,7 +4,7 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import {ScrollEnabledProvider, useScrollEnabled} from '../contexts';
 import {useNavigation} from '@react-navigation/native';
 // prettier-ignore
-import {RootStackParamList} from './StackNavigator';
+import {RootStackParamList} from './Main';
 import {StackNavigationProp} from '@react-navigation/stack';
 import ListItem from './ListItem';
 import {AlarmType, deleteAllAlarms, getAlarms} from '../libs/alarm';

--- a/srcs/screen/Main.tsx
+++ b/srcs/screen/Main.tsx
@@ -30,7 +30,7 @@ export type RootStackParamList = {
 const ModalStack = createNativeStackNavigator<ModalStackParamList>();
 const RootStack = createNativeStackNavigator<RootStackParamList>();
 
-const StackNavigator = () => {
+const Main = () => {
   return (
     <RootStack.Navigator initialRouteName="Home">
       <RootStack.Screen name="Home" component={Home} />
@@ -80,4 +80,4 @@ const AddAlarmModal = () => {
   );
 };
 
-export default StackNavigator;
+export default Main;

--- a/srcs/screen/notUsing/TabNavigator.tsx
+++ b/srcs/screen/notUsing/TabNavigator.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type {RouteProp, ParamListBase} from '@react-navigation/native';
-import StackNavigator from './StackNavigator';
+import StackNavigator from '../Main';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import Icon from 'react-native-vector-icons/Ionicons';
 import {MD2Colors as Colors} from 'react-native-paper';

--- a/srcs/screen/notUsing/Timer.tsx
+++ b/srcs/screen/notUsing/Timer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {StyleSheet, SafeAreaView, View} from 'react-native';
-import {ScrollEnabledProvider} from '../contexts';
+import {ScrollEnabledProvider} from '../../contexts';
 // import {useNavigation} from '@react-navigation/native';
 
 export default function Timer() {


### PR DESCRIPTION
## 개요
TabNavigator, Timer 기능은 mvp 개발 중 사용하지 않기로 함.
StackNavigator를 더 명확한 컴포넌트 이름으로 바꿈.

## 작업내용
- Tap Navigator 사용하지 않고 alarm 메인 스크린(Main.tsx)를 바로 App.tsx 에서 사용하도록 함.
- StackNavigator.tsx => Main.tsx
- AddAlarm.tsx => { AddAlarm.tsx, AddAlarm.style.tsx } 코드와 스타일을 분리함.
- TabNavigator, Timer => notUsing directory로 이동

## 주의사항
