### PR TITLE
[FEATURE] FlatList fadeout animation 개발

### DIFF
--- a/srcs/common/constant.ts
+++ b/srcs/common/constant.ts
@@ -1,3 +1,5 @@
+import {Dimensions} from 'react-native';
+
 export enum SOUND {
   SOUND1 = 'Sound 1',
   SOUND2 = 'Sound 2',
@@ -16,3 +18,4 @@ export enum REPEAT {
   SATURDAY = '토요일',
   SUNDAY = '일요일',
 }
+export const {height: SCREEN_HEIGHT} = Dimensions.get('screen');

--- a/srcs/screens/home/components/ListItem.tsx
+++ b/srcs/screens/home/components/ListItem.tsx
@@ -46,11 +46,8 @@ export default function ListItem(props: listItemProps) {
   return (
     <Swipeable
       childrenContainerStyle={{backgroundColor: theme.color.black}}
-      renderRightActions={(progress, dragAnimatedValue) =>
-        renderRightActions(progress, dragAnimatedValue)
-      }>
-      <View
-        style={active ? styles.itemView : [styles.itemView, {opacity: 0.35}]}>
+      renderRightActions={renderRightActions}>
+      <View style={viewStyle(active).itemView}>
         <View style={[styles.timeView]}>
           <Text style={[styles.timeText]}>{moment(date).format('HH:mm')}</Text>
           <Switch
@@ -67,7 +64,19 @@ export default function ListItem(props: listItemProps) {
     </Swipeable>
   );
 }
-
+const viewStyle = (active: boolean) =>
+  StyleSheet.create({
+    itemView: {
+      display: 'flex',
+      opacity: active ? 1 : 0.35,
+      flexDirection: 'column',
+      marginVertical: 8,
+      paddingTop: 4,
+      paddingBottom: 12,
+      paddingHorizontal: 16,
+      backgroundColor: theme.color.background_grey,
+    },
+  });
 const styles = StyleSheet.create({
   itemView: {
     display: 'flex',

--- a/srcs/screens/home/components/ListItem.tsx
+++ b/srcs/screens/home/components/ListItem.tsx
@@ -66,7 +66,7 @@ export default function ListItem(props: listItemProps) {
                 (itemHeight + 16) * index - (listHeight - 200), // 16: margin, 200: header
                 (itemHeight + 16) * (index + 1) - (listHeight - 200),
               ],
-              outputRange: [0.5, 1],
+              outputRange: [0.6, 1],
             }),
           },
         ]}>

--- a/srcs/screens/home/components/ListItem.tsx
+++ b/srcs/screens/home/components/ListItem.tsx
@@ -1,4 +1,9 @@
-import React, {Dispatch, SetStateAction, useRef} from 'react';
+import React, {
+  Dispatch,
+  SetStateAction,
+  useLayoutEffect,
+  useState,
+} from 'react';
 import {Swipeable} from 'react-native-gesture-handler';
 import {
   Animated,
@@ -17,10 +22,14 @@ import Icon from '@common/Icon';
 
 type listItemProps = CreateAlarmType & {
   setUpdated: Dispatch<SetStateAction<boolean>>;
+  listHeight: number;
+  index: number;
+  scrollY: Animated.Value;
 };
 
 export default function ListItem(props: listItemProps) {
-  const {active, soundName, date, message, setUpdated} = props;
+  const {active, date, message, setUpdated, index, listHeight, scrollY} = props;
+  const [itemHeight, setItemHeight] = useState<number>(0);
 
   const renderRightActions = (
     progress: Animated.AnimatedInterpolation<any>,
@@ -47,7 +56,20 @@ export default function ListItem(props: listItemProps) {
     <Swipeable
       childrenContainerStyle={{backgroundColor: theme.color.black}}
       renderRightActions={renderRightActions}>
-      <View style={viewStyle(active).itemView}>
+      <Animated.View
+        onLayout={e => setItemHeight(e.nativeEvent.layout.height)}
+        style={[
+          viewStyle(active).itemView,
+          {
+            opacity: scrollY.interpolate({
+              inputRange: [
+                (itemHeight + 16) * index - (listHeight - 200), // 16: margin, 200: header
+                (itemHeight + 16) * (index + 1) - (listHeight - 200),
+              ],
+              outputRange: [0.5, 1],
+            }),
+          },
+        ]}>
         <View style={[styles.timeView]}>
           <Text style={[styles.timeText]}>{moment(date).format('HH:mm')}</Text>
           <Switch
@@ -60,7 +82,7 @@ export default function ListItem(props: listItemProps) {
           <Text style={[styles.messageText]}>{message}</Text>
           <Text style={[styles.messageText]}>{moment(date).fromNow()}</Text>
         </View>
-      </View>
+      </Animated.View>
     </Swipeable>
   );
 }

--- a/srcs/screens/home/index.tsx
+++ b/srcs/screens/home/index.tsx
@@ -1,5 +1,12 @@
 import React, {useEffect, useLayoutEffect, useState} from 'react';
-import {FlatList, SafeAreaView, View, Text, Pressable} from 'react-native';
+import {
+  SafeAreaView,
+  View,
+  Text,
+  Pressable,
+  Animated,
+  LayoutRectangle,
+} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 // import {getAlarms} from '../../libs/alarm';
@@ -8,6 +15,7 @@ import {AlarmType} from '@common/types';
 import ListItem from './components/ListItem';
 import {RootStackParamList} from 'App';
 import Icon from '@common/Icon';
+import {SCREEN_HEIGHT} from '@common/constant';
 // import {getAlarm} from '@srcs/libs/alarm/get';
 
 /*
@@ -20,8 +28,32 @@ type homeScreenProp = NativeStackNavigationProp<RootStackParamList, 'Home'>;
 export default function Home() {
   const navigation = useNavigation<homeScreenProp>();
   // const [alarmList, setAlarmList] = useState<AlarmType>();
-  const alarmList: AlarmType[] = [{id: '1', title: 'hello', repeatDays: []}];
+  const [listHeight, setListHeight] = useState<number>(0);
+  const alarmList: AlarmType[] = [
+    {id: '1', title: 'hello', repeatDays: []},
+    {id: '2', title: 'hello', repeatDays: []},
+    {id: '3', title: 'hello', repeatDays: []},
+    {id: '4', title: 'hello', repeatDays: []},
+    {id: '5', title: 'hello', repeatDays: []},
+    {id: '6', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+    {id: '7', title: 'hello', repeatDays: []},
+  ];
   const [updated, setUpdated] = useState<boolean>(true);
+  const scrollY = React.useRef(new Animated.Value(0)).current;
   useLayoutEffect(() => {
     navigation.setOptions({
       headerLeft: () => (
@@ -48,24 +80,41 @@ export default function Home() {
       setUpdated(false);
     }
   }, [updated]);
-
   return (
     <SafeAreaView style={[{flex: 1, backgroundColor: theme.color.black}]}>
-      <View style={{flex: 1}}>
-        <FlatList
+      <View
+        style={{flex: 9}}
+        onLayout={e => setListHeight(e.nativeEvent.layout.height)}>
+        <Animated.FlatList
           scrollEnabled={true}
+          onScroll={Animated.event(
+            [{nativeEvent: {contentOffset: {y: scrollY}}}],
+            {useNativeDriver: true},
+          )}
           data={alarmList}
           keyExtractor={(item, index) => index.toString()}
-          renderItem={(result: {item: AlarmType}) => (
+          renderItem={({item, index}) => (
             <ListItem
-              active={false}
+              active={true}
               date={new Date()}
               message={'hello'}
               soundName={'marimba'}
               setUpdated={setUpdated}
+              scrollY={scrollY}
+              index={index}
+              listHeight={listHeight}
             />
           )}
         />
+      </View>
+      <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
+        <Text
+          style={{
+            color: theme.color.text_grey,
+            fontSize: theme.fontSize.lg,
+          }}>
+          다음 알람이 몇 분 뒤에 울립니다.
+        </Text>
       </View>
     </SafeAreaView>
   );


### PR DESCRIPTION
## 개요
Home화면의 FlatList 하단 아이템에 opacity fadeout 효과.
Animation은 이동하는 정도 inputRange 대비 outputRange으로 스타일 속성을 변경할 수 있음
## 작업내용
```
 opacity: scrollY.interpolate({
              inputRange: [
                (itemHeight + 16) * index - (listHeight - 200), // 16: margin, 200: header
                (itemHeight + 16) * (index + 1) - (listHeight - 200),
              ],
              outputRange: [0.6, 1],
            }),
```
- 리스트의 아이템 하나의 크기를 기준으로 투명도 변경효과 필요
`inputRange: [(itemHeight) * index, (itemHeight) * (index + 1),] (ascending order)`
- input 값이 변경됨에 따라 opacity animation 효과
`outputRange: [0.6, 1]`
- FlatList 시작 지점이 아닌 FlatList의 하단부가 기준이 되어야함
`(itemHeight) * index - (listHeight - 200), (itemHeight) * (index + 1) - (listHeight - 200)`

각각의 아이템들은 각자의 인덱스를 기준으로 인덱스 한칸 만큼 움직이는 것을 기준으로 animation을 적용함
![Simulator Screen Shot - iPhone 14 - 2022-12-07 at 13 19 43](https://user-images.githubusercontent.com/63241308/206087407-287aa33e-e0ec-4f86-b7cd-79915181212d.png)

## 주의사항
margin 값, header size 값 설정은 최적화 필요. 다른 디바이스에서도 올바르게 동작하는지 확인 필요